### PR TITLE
"Scan Into Chapel" Button removed from ProfileScreen

### DIFF
--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -10,10 +10,6 @@ const LINKS = [
     text: 'Settings',
   },
   {
-    screen: 'Redirect',
-    text: 'Scan Into Chapel',
-  },
-  {
     screen: 'TermsOfUse',
     text: 'Terms of Use',
   },


### PR DESCRIPTION
Removed "Scan into Chapel" button from the ProfileScreen:
Removed button from LINKS array in ProfileScreen.js