### PR TITLE
12 web app not compiling

### DIFF
--- a/firebase/firebaseConfig.js
+++ b/firebase/firebaseConfig.js
@@ -6,6 +6,7 @@ import {
 } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyALnurIGO_Kpkhn2rWKpcMLhWdAw7awo3E',
@@ -19,7 +20,12 @@ const firebaseConfig = {
 
 // Initialize Firebase
 export const FIREBASE_APP = initializeApp(firebaseConfig);
-export const FIREBASE_AUTH = initializeAuth(FIREBASE_APP, {
-  persistence: getReactNativePersistence(AsyncStorage),
-});
+export const FIREBASE_AUTH = initializeAuth(
+  FIREBASE_APP,
+  Platform.OS !== 'web'
+    ? {
+        persistence: getReactNativePersistence(AsyncStorage),
+      }
+    : null,
+);
 export const FIRESTORE_DB = getFirestore(FIREBASE_APP);

--- a/firebase/firebaseConfig.js
+++ b/firebase/firebaseConfig.js
@@ -1,8 +1,8 @@
 import { initializeApp } from 'firebase/app';
 import {
-  getAuth,
   initializeAuth,
   getReactNativePersistence,
+  browserLocalPersistence,
 } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -20,12 +20,10 @@ const firebaseConfig = {
 
 // Initialize Firebase
 export const FIREBASE_APP = initializeApp(firebaseConfig);
-export const FIREBASE_AUTH = initializeAuth(
-  FIREBASE_APP,
-  Platform.OS !== 'web'
-    ? {
-        persistence: getReactNativePersistence(AsyncStorage),
-      }
-    : null,
-);
+export const FIREBASE_AUTH = initializeAuth(FIREBASE_APP, {
+  persistence:
+    Platform.OS === 'web'
+      ? browserLocalPersistence
+      : getReactNativePersistence(AsyncStorage),
+});
 export const FIRESTORE_DB = getFirestore(FIREBASE_APP);

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -50,9 +50,9 @@ const LoginScreen = ({ navigation }) => {
           underlineColor="transparent"
           theme={{ colors: { primary: '#002857' } }}
           returnKeyType="next"
-          onSubmitEditing={() => {
-            this.PasswordInput.focus();
-          }}
+          // onSubmitEditing={() => {
+          //   this.PasswordInput.focus();
+          // }}
           blurOnSubmit={false}
         />
         <TextInput

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -64,9 +64,9 @@ const LoginScreen = ({ navigation }) => {
           textContentType="password"
           secureTextEntry={hidePass ? true : false}
           autoCorrect={false}
-          ref={(input) => {
-            this.PasswordInput = input;
-          }}
+          // ref={(input) => {
+          //   this.PasswordInput = input;
+          // }}
           underlineColor="transparent"
           theme={{ colors: { primary: '#002857' } }}
           right={


### PR DESCRIPTION
Fixes #12 

Issue is with `getReactNativePersistence` function not being supported by web. App now uses `browserLocalPersistence` when compiling for web.

Additionally, found compilation issues involving forward refs in the web. Disabled those on the login screen. Please advise: if any other forward refs are found, we may need to do some refactoring across the board to either remove them completely or check OS before utilizing.