### PR TITLE
Remove redundant register heading

### DIFF
--- a/src/screens/RegisterScreen.js
+++ b/src/screens/RegisterScreen.js
@@ -67,7 +67,7 @@ const RegisterScreen = () => {
       style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
-      <Text style={styles.title}>Register</Text>
+      {/* <Text style={styles.title}>Register</Text> */}
       <View style={styles.inputContainer}>
         <TextInput
           style={styles.input}


### PR DESCRIPTION
Resolves #52 

Commented out redundant heading

Left in the code because we may want to keep that one and remove the heading one -- that's a decision to be made after MVP.